### PR TITLE
L2 Regularization was added to dense layers

### DIFF
--- a/Analysis/combinedmodel.py
+++ b/Analysis/combinedmodel.py
@@ -279,9 +279,9 @@ print(bodies_model.output)
 print(headlines_model.output)
 finalModel = Concatenate()([bodies_model.output, headlines_model.output])
 finalModel = Flatten()(finalModel)
-finalModel = Dense(1024, activation='relu') (finalModel)
-finalModel = Dense(1024, activation='relu') (finalModel)
-finalModel = Dense(1024, activation='relu') (finalModel)
+finalModel = Dense(1024, activation='relu', kernel_regularizer=regularizers.l2(0.001)) (finalModel)
+finalModel = Dense(1024, activation='relu', kernel_regularizer=regularizers.l2(0.001)) (finalModel)
+finalModel = Dense(1024, activation='relu', kernel_regularizer=regularizers.l2(0.001)) (finalModel)
 finalModel = Dense(4, activation='softmax') (finalModel)
 #0,1,2,3
 #0: [1,0,0,0]


### PR DESCRIPTION
I added L2 regularization rate of .001 over three layers to help reduce overfitting. I was not able to test if there any changes since I do not have the original data set path file configured. It will be tested in the future. 